### PR TITLE
added a delay to emitting the reload signal

### DIFF
--- a/main.js
+++ b/main.js
@@ -346,8 +346,11 @@ function updateStatus() {
             // emit the reload signal if the config instructs
             // to reload clients following deployment
             if (config.reloadClientsFollowingDeployment) {
-                console.log("Client reload flag set, emitting reload signal");
-                io.emit("reload");
+                console.log("Client reload flag set, emitting reload signal in 20s");
+                setTimeout(() => {
+                    console.log("Emitting client reload signal");
+                    io.emit("reload");
+                }, 20000);
             }
             
             io.emit("subreddits", subreddits);


### PR DESCRIPTION
llowing #90 the first check is so fucking fast that it seems the vast majority of the clients haven’t even established a connection with the new process *by the time the first check is complete*

adding a delay to the signal to therefore try and ensure clients are connected and can therefore receive the signal

better problems to have i guess