### PR TITLE
next deployment: url migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Reddark (fork)](https://reddark-digitalocean-7lhfr.ondigitalocean.app)
+# [Reddark (fork)](https://reddark.io/)
 A website to watch subreddits go dark in realtime. Fork of the repository by [Tanza3D](https://github.com/Tanza3D).
 
 ## Subreddits

--- a/README.md
+++ b/README.md
@@ -2,8 +2,17 @@
 A website to watch subreddits go dark in realtime. Fork of the repository by [Tanza3D](https://github.com/Tanza3D).
 
 ## Subreddits
-Reddark pulls the list of participating subreddits from the [threads on r/ModCoord](https://reddit.com/r/ModCoord/comments/1401qw5/incomplete_and_growing_list_of_participating/). If you are the moderator of a sub that is going dark and that is not displayed on Reddark, you can [message the r/ModCoord moderators](https://reddit.com/message/compose?to=/r/ModCoord) to request that the subreddit is added to the relevant thread.
+Reddark pulls the list of participating subreddits from the [r/ModCoord wiki](https://reddit.com/r/ModCoord/wiki/index). If you are the moderator of a sub that is going dark and that is not displayed on Reddark, you can [message the r/ModCoord moderators](https://reddit.com/message/compose?to=/r/ModCoord) to request that the subreddit is added to the wikipage.
+
+## Features
+If you have an idea for a feature you would like to see, please [submit an issue](https://github.com/username-is-required/reddark/issues/new?title=idea:%20[your%20idea%20here]) with the details!
+
+## Bugs
+There are not any currently known bugs with this fork of Reddark. If you encounter an problem, please [submit an issue](https://github.com/username-is-required/reddark/issues/new?title=issue:%20[issue%20description%20here]) with the details, and it will be looked into.
 
 ## Technologies
 This is using Express to host the frontend and Socket.io to serve data. Quite simple code, and not too hard to get your head around.
 This is based on the [Original work of D4llo](https://github.com/D4llo/Reddark) with permission.
+
+## License
+This repository is licensed under the [GNU Affero General Public License v3.0](https://github.com/username-is-required/reddark/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ If you have an idea for a feature you would like to see, please [submit an issue
 There are not any currently known bugs with this fork of Reddark. If you encounter an problem, please [submit an issue](https://github.com/username-is-required/reddark/issues/new?title=issue:%20[issue%20description%20here]) with the details, and it will be looked into.
 
 ## Technologies
-This is using Express to host the frontend and Socket.io to serve data. Quite simple code, and not too hard to get your head around.
-This is based on the [Original work of D4llo](https://github.com/D4llo/Reddark) with permission.
+This is using Express to host the frontend and Socket.io to serve data. Requests to Reddit are sent via the `/api/info.json` endpoint, which is used to get the statuses of 100 subreddits at a time.
+
+The [main Reddark repository](https://github.com/tanza3d/reddark) was based on the [original work of D4llo](https://github.com/D4llo/Reddark).
 
 ## License
 This repository is licensed under the [GNU Affero General Public License v3.0](https://github.com/username-is-required/reddark/blob/main/LICENSE).

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         
        <!-- <h3>Notes:</h3>-->
         <p style="padding-top: 10px;">This Reddark instance is a fork of the <a href="https://reddark.untone.uk/" target="_blank">original site</a>. Feel free to use whichever version of Reddark you prefer!</p>
-        <p style="padding-top: 10px;">This instance (formerly available at ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected.</p>
+        <p style="padding-top: 10px;">This instance (formerly available at ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected :)</p>
         <!--<p>Due to slow rollout on reddit's side, some subreddits may flash public and private, if this is happening, it
             means that the subreddit just changed their publicity type.</p>-->
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
         
        <!-- <h3>Notes:</h3>-->
         <p style="padding-top: 10px;">This Reddark instance is a fork of the <a href="https://reddark.untone.uk/" target="_blank">original site</a>. Feel free to use whichever version of Reddark you prefer!</p>
+        <p style="padding-top: 10px;">This instance (formerly hosted on digitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>.
         <!--<p>Due to slow rollout on reddit's side, some subreddits may flash public and private, if this is happening, it
             means that the subreddit just changed their publicity type.</p>-->
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reddark (fork)</title>
     <meta name="description" content="An open source website to watch subreddits going dark">
+    <link rel="canonical" href="https://reddark.io/">
     <link rel="icon"
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 115 115%22><text y=%22.9em%22 font-size=%2290%22>✊</text></svg>">
 </head>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         
        <!-- <h3>Notes:</h3>-->
         <p style="padding-top: 10px;">This Reddark instance is a fork of the <a href="https://reddark.untone.uk/" target="_blank">original site</a>. Feel free to use whichever version of Reddark you prefer!</p>
-        <p style="padding-top: 10px;">This instance (formerly available at ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected :)</p>
+        <p style="padding-top: 10px;">This instance (previously available via ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected :)</p>
         <!--<p>Due to slow rollout on reddit's side, some subreddits may flash public and private, if this is happening, it
             means that the subreddit just changed their publicity type.</p>-->
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         
        <!-- <h3>Notes:</h3>-->
         <p style="padding-top: 10px;">This Reddark instance is a fork of the <a href="https://reddark.untone.uk/" target="_blank">original site</a>. Feel free to use whichever version of Reddark you prefer!</p>
-        <p style="padding-top: 10px;">This instance (formerly hosted on digitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>.
+        <p style="padding-top: 10px;">This instance (formerly available at ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected.</p>
         <!--<p>Due to slow rollout on reddit's side, some subreddits may flash public and private, if this is happening, it
             means that the subreddit just changed their publicity type.</p>-->
 

--- a/main.js
+++ b/main.js
@@ -32,6 +32,11 @@ const io = new Server(server, {
     allowEIO3: true
 });
 
+// redirect to the new url if we're here from the digitalocean instance
+app.get('/reddark-digitalocean-7lhfr.ondigitalocean.app/', (req, res) => {
+    return res.redirect(301, "https://reddark.io/");
+});
+
 // set up the static files - index.html and the public directory
 app.get('/', (req, res) => {
     res.sendFile(__dirname + '/index.html');


### PR DESCRIPTION
migrating urls from https://reddark-digitalocean-7lhfr.ondigitalocean.app/ to https://reddark.io/

this deployment will redirect all those that use the `.ondigitalocean.app` url to the new `reddark.io` url