### PR TITLE
new feature: autofiltering

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -3,6 +3,7 @@ module.exports = {
     intervalBetweenRequests: 7,
     updateInterval: 10000,
     listRefreshInterval: 1800000,
-    url: "https://reddark-digitalocean-7lhfr.ondigitalocean.app/",
-    "reloadClientsFollowingDeployment": true
+    url: "https://reddark.io/",
+    "reloadClientsFollowingDeployment": true,
+    "allowedHourlyStatusChanges": 3
 }

--- a/config.js.example
+++ b/config.js.example
@@ -5,5 +5,5 @@ module.exports = {
     listRefreshInterval: 1800000,
     url: "https://reddark.io/",
     "reloadClientsFollowingDeployment": true,
-    "allowedHourlyStatusChanges": 3
+    "allowedHourlyStatusChanges": 3 // a quick poll in the discord indicated the most popular choice was allowing 3 alerts in a given hour before the rest are filtered out
 }

--- a/filteredSubs.js
+++ b/filteredSubs.js
@@ -1,8 +1,7 @@
 // a list of filtered subs. all alerts from these subs will be filtered - none will be shown to clients.
 // this is because these subs have been previously known to spam changes to their subreddit's status.
-// ** PLEASE INCLUDE ALL SUB NAMES IN LOWERCASE **
 
-module.exports = [
+var filteredSubs = [
     // "r/bi_irl",
     // "r/suddenlybi",
     // "r/ennnnnnnnnnnnbbbbbby",
@@ -13,3 +12,10 @@ module.exports = [
     // "r/inzaghi",
     "r/gtafk",
 ];
+
+// set them all to lowercase (just in case)
+for (let index in filteredSubs)
+    filteredSubs[index] = filteredSubs[index].toLowerCase();
+
+
+module.exports = filteredSubs;

--- a/filteredSubs.js
+++ b/filteredSubs.js
@@ -1,0 +1,11 @@
+module.exports = [
+    // "r/bi_irl",
+    // "r/suddenlybi",
+    // "r/ennnnnnnnnnnnbbbbbby",
+    // "r/seriouslyfuckspez",
+    // "r/feemagers",
+    // "r/brexitatemyface",
+    // "r/emoney",
+    // "r/inzaghi",
+    "r/gtafk",
+];

--- a/filteredSubs.js
+++ b/filteredSubs.js
@@ -1,3 +1,7 @@
+// a list of filtered subs. all alerts from these subs will be filtered - none will be shown to clients.
+// this is because these subs have been previously known to spam changes to their subreddit's status.
+// ** PLEASE INCLUDE ALL SUB NAMES IN LOWERCASE **
+
 module.exports = [
     // "r/bi_irl",
     // "r/suddenlybi",

--- a/index.html
+++ b/index.html
@@ -63,4 +63,4 @@
     </div>
 </body>
 <script src="/socket.io/socket.io.js"></script>
-<script src="index.js?v=25"></script>
+<script src="index.js?v=26"></script>

--- a/main.js
+++ b/main.js
@@ -313,7 +313,7 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                  
                     if (firstCheck) {
                         // figure out if we should display an alert
-                        var displayAlert = subStatusChangeCounts[subName] <= 3; // a quick poll in the discord indicated the most popular choice was allowing 3 alerts in a given hour before the rest are filtered out
+                        var displayAlert = !filteredSubs.includes(subName.toLowerCase()) && subStatusChangeCounts[subName] <= 3; // a quick poll in the discord indicated the most popular choice was allowing 3 alerts in a given hour before the rest are filtered out
                         // <add checking code here>
                         
                         io.emit("updatenew", {

--- a/main.js
+++ b/main.js
@@ -327,7 +327,7 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                         var logText = knownSubStatus + "→" + subStatus + ": " + subName + " (" + privateCount + ")";
                         
                         if (!displayAlert) logText += " (alert filtered)"; // mention in logs if alert filtered
-                        else subStatusChangeCounts[subname]++; // increment the count if the alert will be displayed
+                        else subStatusChangeCounts[subName]++; // increment the count if the alert will be displayed
                         
                         console.log(logText);
                     } else {

--- a/main.js
+++ b/main.js
@@ -4,7 +4,8 @@ const http = require('http');
 const { Server } = require("socket.io");
 
 var request = require("./requests.js");
-var config = require("./config.js")
+var config = require("./config.js");
+var filteredSubs = require("./filteredSubs.js");
 
 // helper function to wait for some time before continuing
 function wait(msDelay) {

--- a/main.js
+++ b/main.js
@@ -246,7 +246,7 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                 const subIndexInBatch = subNameBatch.findIndex(el => {
                     return el.toLowerCase() == data["display_name"].toLowerCase();
                 });
-                const subName = data["display_name_prefixed"];
+                var subName = data["display_name_prefixed"];
 
                 if (subIndexInBatch == -1) {
                     // why the hell do we have a sub we didn't request
@@ -268,6 +268,10 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                 const subIndex = subreddits[sectionIndex].findIndex(el => {
                     return el["name"].toLowerCase() == subName.toLowerCase();
                 });
+
+                // update the subname to the one we have
+                // (this helps to prevent problems caused by differencss in capitalisation)
+                subName = subreddits[sectionIndex][subIndex]["name"];
 
                 // get the sub's currently recorded status
                 const knownSubStatus = subreddits[sectionIndex][subIndex]["status"];
@@ -315,7 +319,7 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                         // figure out if we should display an alert
                         var displayAlert = (
                             !filteredSubs.includes(subName.toLowerCase())
-                            && subStatusChangeCounts[subreddits[sectionIndex][subIndex]["name"]] < config.allowedHourlyStatusChanges
+                            && subStatusChangeCounts[subName] < config.allowedHourlyStatusChanges
                         );
                         
                         io.emit("updatenew", {

--- a/main.js
+++ b/main.js
@@ -273,10 +273,17 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                     subreddits[sectionIndex][subIndex]["status"] = subStatus;
                  
                     if (firstCheck) {
-                        io.emit("updatenew", subreddits[sectionIndex][subIndex]);
+                        // figure out if we should display an alert
+                        var displayAlert = true;
+                        // <add checking code here>
+                        
+                        io.emit("updatenew", {
+                            "subData": subreddits[sectionIndex][subIndex],
+                            "displayAlert": displayAlert
+                        });
                         console.log(knownSubStatus + "→" + subStatus + ": " + subName + " (" + privateCount + ")");
                     } else {
-                        io.emit("update", subreddits[sectionIndex][subIndex]);
+                        io.emit("update", {"subData": subreddits[sectionIndex][subIndex]});
                     }
                 }
             }

--- a/main.js
+++ b/main.js
@@ -199,7 +199,7 @@ function initSubStatusChangeCounts(resetToZero = false) {
             var prevCount = 0;
             
             if (!resetToZero) {
-                prevCount = subStatusChangeCounts[sub.name];
+                prevCount = subStatusChangeCountsCopy[sub.name];
 
                 if (prevCount === undefined) {
                     prevCount = 0;

--- a/main.js
+++ b/main.js
@@ -479,7 +479,7 @@ async function run() {
     setInterval(() => {
         console.log("Resetting alert autofilter counts"); // not the best wording i know
         initSubStatusChangeCounts(true);
-    });
+    }, 3600000);
 }
 
 

--- a/main.js
+++ b/main.js
@@ -313,7 +313,10 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                  
                     if (firstCheck) {
                         // figure out if we should display an alert
-                        var displayAlert = !filteredSubs.includes(subName.toLowerCase()) && subStatusChangeCounts[subName] <= 3; // a quick poll in the discord indicated the most popular choice was allowing 3 alerts in a given hour before the rest are filtered out
+                        var displayAlert = (
+                            !filteredSubs.includes(subName.toLowerCase())
+                            && subStatusChangeCounts[subName] <= config.allowedHourlyStatusChanges
+                        );
                         // <add checking code here>
                         
                         io.emit("updatenew", {

--- a/main.js
+++ b/main.js
@@ -315,7 +315,7 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                         // figure out if we should display an alert
                         var displayAlert = (
                             !filteredSubs.includes(subName.toLowerCase())
-                            && subStatusChangeCounts[subName] <= config.allowedHourlyStatusChanges
+                            && subStatusChangeCounts[subName] < config.allowedHourlyStatusChanges
                         );
                         
                         io.emit("updatenew", {

--- a/main.js
+++ b/main.js
@@ -317,7 +317,6 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                             !filteredSubs.includes(subName.toLowerCase())
                             && subStatusChangeCounts[subName] <= config.allowedHourlyStatusChanges
                         );
-                        // <add checking code here>
                         
                         io.emit("updatenew", {
                             "subData": subreddits[sectionIndex][subIndex],

--- a/main.js
+++ b/main.js
@@ -183,7 +183,7 @@ server.listen(config.port, () => {
 var subStatusChangeCounts = {};
 
 // a function to init that variable above
-function initSubStatusChangeCounts() {
+function initSubStatusChangeCounts(resetToZero = false) {
     // make a copy -- counts currently in there will be brought over
     // (providing the releavnt sub is still present in the new list, of course)
     subStatusChangeCountsCopy = Object.assign({}, subStatusChangeCounts);
@@ -196,10 +196,14 @@ function initSubStatusChangeCounts() {
     for (let section of subreddits) {
         for (let sub of section) {
             // if no prev count we'll start them at zero
-            var prevCount = subStatusChangeCounts[sub.name];
+            var prevCount = 0;
+            
+            if (!resetToZero) {
+                prevCount = subStatusChangeCounts[sub.name];
 
-            if (prevCount === undefined) {
-                prevCount = 0;
+                if (prevCount === undefined) {
+                    prevCount = 0;
+                }
             }
             
             // add it in
@@ -464,6 +468,12 @@ async function run() {
         console.log("refreshSubredditList flag set to true");
         refreshSubredditList = true;
     }, config.listRefreshInterval);
+
+    // every hour, reset the subStatusChangeCounts
+    setInterval(() => {
+        console.log("Resetting alert autofilter counts"); // not the best wording i know
+        initSubStatusChangeCounts(true);
+    });
 }
 
 

--- a/main.js
+++ b/main.js
@@ -313,14 +313,20 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                  
                     if (firstCheck) {
                         // figure out if we should display an alert
-                        var displayAlert = true;
+                        var displayAlert = subStatusChangeCounts[subName] <= 3; // a quick poll in the discord indicated the most popular choice was allowing 3 alerts in a given hour before the rest are filtered out
                         // <add checking code here>
                         
                         io.emit("updatenew", {
                             "subData": subreddits[sectionIndex][subIndex],
                             "displayAlert": displayAlert
                         });
-                        console.log(knownSubStatus + "→" + subStatus + ": " + subName + " (" + privateCount + ")");
+
+                        var logText = knownSubStatus + "→" + subStatus + ": " + subName + " (" + privateCount + ")";
+                        
+                        if (!displayAlert) logText += " (alert filtered)"; // mention in logs if alert filtered
+                        else subStatusChangeCounts[subname]++; // increment the count if the alert will be displayed
+                        
+                        console.log(logText);
                     } else {
                         io.emit("update", {"subData": subreddits[sectionIndex][subIndex]});
                     }

--- a/main.js
+++ b/main.js
@@ -193,8 +193,8 @@ function initSubStatusChangeCounts(resetToZero = false) {
 
     // loop over the list of subs and add each one to the list.
     // if a sub had a count in the previous object, copy it over
-    for (let section of subreddits) {
-        for (let sub of section) {
+    for (let section in subreddits) {
+        for (let sub of subreddits[section]) {
             // if no prev count we'll start them at zero
             var prevCount = 0;
             

--- a/main.js
+++ b/main.js
@@ -315,7 +315,7 @@ function loadSubredditBatchStatus(subNameBatch, sectionIndex) {
                         // figure out if we should display an alert
                         var displayAlert = (
                             !filteredSubs.includes(subName.toLowerCase())
-                            && subStatusChangeCounts[subName] < config.allowedHourlyStatusChanges
+                            && subStatusChangeCounts[subreddits[sectionIndex][subIndex]["name"]] < config.allowedHourlyStatusChanges
                         );
                         
                         io.emit("updatenew", {

--- a/public/index.js
+++ b/public/index.js
@@ -42,6 +42,9 @@ document.getElementById("enable_sounds").addEventListener("click", function () {
 var socket = io();
 
 // emit client info to socket once connected
+// (this isn't currently listened for, but keeping it here
+// in case we want to get the server to listen for it again
+// in the future)
 socket.on("connect", () => {
     socket.emit("client-info", {
         reloadable: true
@@ -109,16 +112,6 @@ function doScroll(el) {
     window.scrollTo(0, middle);
 }
 
-// not alerting for these subs as they've been spamming
-// back and forth between private and public
-const subsToFilter = [
-    /*"r/bi_irl",
-    "r/suddenlybi",
-    "r/ennnnnnnnnnnnbbbbbby",
-    "r/seriouslyfuckspez"*/
-    "r/gtafk"
-];
-
 function updateSubreddit(data, _new = false) {
     if (!loaded) return;
     
@@ -159,7 +152,7 @@ function updateSubreddit(data, _new = false) {
             dark++;
         }
     } else if (data.status == "restricted") {
-        if (_new && !subsToFilter.includes(data.name.toLowerCase())) {
+        if (_new) {
             var statusUpdateText = "<strong>" + data.name + "</strong><br>" + prevStatus + " → <strong>restricted</strong>";
             if (prevStatus != "private") statusUpdateText += "!";
             

--- a/public/index.js
+++ b/public/index.js
@@ -98,11 +98,15 @@ socket.on('disconnect', function () {
     loaded = false;
 });
 socket.on("updatenew", (data) => {
+    var logstring = "";
     if (data.subData.status == "private" || data.subData.status == "restricted") {
-        console.log("NEW PRIVATE (o7): " + data.subData.name);
+        logstring += "NEW PRIVATE (o7): " + data.subData.name;
     } else {
-        console.log(":/ new public: " + data.subData.name);
+        logstring += ":/ new public: " + data.subData.name;
     }
+    if (!data.displayAlert) logstring += " (alert filtered)";
+    console.log(logstring);
+    
     updateSubreddit(data, true);
 })
 function doScroll(el) {

--- a/public/index.js
+++ b/public/index.js
@@ -152,7 +152,7 @@ function updateSubreddit(data, _new = false) {
             dark++;
         }
     } else if (data.status == "restricted") {
-        if (_new) {
+        if (_new && data.displayAlert) {
             var statusUpdateText = "<strong>" + data.name + "</strong><br>" + prevStatus + " → <strong>restricted</strong>";
             if (prevStatus != "private") statusUpdateText += "!";
             
@@ -170,7 +170,7 @@ function updateSubreddit(data, _new = false) {
             dark++;
         }
     } else {
-        if (_new && !subsToFilter.includes(data.name.toLowerCase())) {
+        if (_new && data.displayAlert) {
             newStatusUpdate("<strong>" + data.name + "</strong><br>" + prevStatus + " → <strong>public</strong> :(", "public", function () {
                 doScroll(subredditElement);
             })

--- a/public/index.js
+++ b/public/index.js
@@ -98,10 +98,10 @@ socket.on('disconnect', function () {
     loaded = false;
 });
 socket.on("updatenew", (data) => {
-    if (data.status == "private" || data.status == "restricted") {
-        console.log("NEW PRIVATE (o7): " + data.name);
+    if (data.subData.status == "private" || data.subData.status == "restricted") {
+        console.log("NEW PRIVATE (o7): " + data.subData.name);
     } else {
-        console.log(":/ new public: " + data.name);
+        console.log(":/ new public: " + data.subData.name);
     }
     updateSubreddit(data, true);
 })
@@ -114,12 +114,16 @@ function doScroll(el) {
 
 function updateSubreddit(data, _new = false) {
     if (!loaded) return;
+
+    const subData = data.subData;
+    const subName = subData.name;
+    const subStatus = subData.status;
     
-    var subredditElement = document.getElementById(data.name);
+    var subredditElement = document.getElementById(subName);
     if (subredditElement == null) {
         // if this happens, the subreddit list has probably been refreshed
         // but not yet emmitted
-        console.log("Skipped over " + data.name + " going " + data.status + ": not in list");
+        console.log("Skipped over " + subName + " going " + subStatus + ": not in list");
         return;
     }
 
@@ -132,10 +136,12 @@ function updateSubreddit(data, _new = false) {
     } else {
         prevStatus = "public";
     }
+
+    const displayAlert = data.displayAlert;
     
-    if (data.status == "private") {
-        if (_new && !subsToFilter.includes(data.name.toLowerCase())) {
-            var statusUpdateText = "<strong>" + data.name + "</strong><br>" + prevStatus + " → <strong>private</strong>";
+    if (subStatus == "private") {
+        if (_new && displayAlert) {
+            var statusUpdateText = "<strong>" + subName + "</strong><br>" + prevStatus + " → <strong>private</strong>";
             if (prevStatus != "restricted") statusUpdateText += "!";
             
             newStatusUpdate(statusUpdateText, "private", function () {
@@ -151,9 +157,9 @@ function updateSubreddit(data, _new = false) {
         } else {
             dark++;
         }
-    } else if (data.status == "restricted") {
-        if (_new && data.displayAlert) {
-            var statusUpdateText = "<strong>" + data.name + "</strong><br>" + prevStatus + " → <strong>restricted</strong>";
+    } else if (subStatus == "restricted") {
+        if (_new && displayAlert) {
+            var statusUpdateText = "<strong>" + subName + "</strong><br>" + prevStatus + " → <strong>restricted</strong>";
             if (prevStatus != "private") statusUpdateText += "!";
             
             newStatusUpdate(statusUpdateText, "restricted", function () {
@@ -170,8 +176,8 @@ function updateSubreddit(data, _new = false) {
             dark++;
         }
     } else {
-        if (_new && data.displayAlert) {
-            newStatusUpdate("<strong>" + data.name + "</strong><br>" + prevStatus + " → <strong>public</strong> :(", "public", function () {
+        if (_new && displayAlert) {
+            newStatusUpdate("<strong>" + subName + "</strong><br>" + prevStatus + " → <strong>public</strong> :(", "public", function () {
                 doScroll(subredditElement);
             })
             
@@ -184,7 +190,7 @@ function updateSubreddit(data, _new = false) {
     }
     
     updateStatusText();
-    subredditElement.querySelector("p").innerHTML = data.status;
+    subredditElement.querySelector("p").innerHTML = subStatus;
 }
 
 function genItem(name, status) {
@@ -195,6 +201,7 @@ function genItem(name, status) {
     _title.innerHTML = name;
     _status.innerHTML = status;
     _title.href = "https://old.reddit.com/" + name;
+    _title.target = "_blank";
     _item.id = name;
     if (status == "private") {
         _item.classList.add("subreddit-private");


### PR DESCRIPTION
automatically filters alerts from subs (for the remainder of the hour) where they have already had three status changes in a given hour — this limit was determined by an unscientific poll in the discord:

![](https://user-images.githubusercontent.com/136007111/246166289-f6190952-efea-4cb3-ac6a-400ce15f5d8a.jpeg)

migrates logic determining whether or not to filter an alert from the frontend to the backend

retains a continuous ‘blocklist’ for subs known to be persistently spamming status changes