### PR TITLE
remove the note about the url change

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         
        <!-- <h3>Notes:</h3>-->
         <p style="padding-top: 10px;">This Reddark instance is a fork of the <a href="https://reddark.untone.uk/" target="_blank">original site</a>. Feel free to use whichever version of Reddark you prefer!</p>
-        <p style="padding-top: 10px;">This instance (previously available via ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected :)</p>
+        <!--<p style="padding-top: 10px;">This instance (previously available via ondigitalocean.app) has recently changed URL to <a href="https://reddark.io/">reddark.io</a>. If you visited the ondigitalocean.app URL, you have been redirected :)</p>-->
         <!--<p>Due to slow rollout on reddit's side, some subreddits may flash public and private, if this is happening, it
             means that the subreddit just changed their publicity type.</p>-->
 


### PR DESCRIPTION
i want to leave it up for maybe another day or so (or maybe a little bit less), then we’ll get rid of it